### PR TITLE
Fix bugs that can't serialize primitive array type

### DIFF
--- a/framework/src/main/java/com/nhnent/haste/framework/security/AesCryptoProvider.java
+++ b/framework/src/main/java/com/nhnent/haste/framework/security/AesCryptoProvider.java
@@ -53,6 +53,7 @@ public class AesCryptoProvider implements CryptoProvider {
         }
     }
 
+    @Override
     public byte[] decrypt(byte[] data) {
         return decrypt(data, 0, data.length);
     }

--- a/protocol/src/main/java/com/nhnent/haste/protocol/data/ArrayUtils.java
+++ b/protocol/src/main/java/com/nhnent/haste/protocol/data/ArrayUtils.java
@@ -1,0 +1,96 @@
+/*
+* Copyright 2016 NHN Entertainment Corp.
+*
+* NHN Entertainment Corp. licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.nhnent.haste.protocol.data;
+
+class ArrayUtils {
+    static byte[] toByteArray(Object value) {
+        if (value instanceof byte[])
+            return (byte[]) value;
+
+        Byte[] src = (Byte[]) value;
+        byte[] dst = new byte[src.length];
+        for (int i = 0; i < src.length; i++)
+            dst[i] = src[i];
+        return dst;
+    }
+
+    static boolean[] toBooleanArray(Object value) {
+        if (value instanceof boolean[])
+            return (boolean[]) value;
+
+        Boolean[] src = (Boolean[]) value;
+        boolean[] dst = new boolean[src.length];
+        for (int i = 0; i < src.length; i++)
+            dst[i] = src[i];
+        return dst;
+    }
+
+    static short[] toShortArray(Object value) {
+        if (value instanceof short[])
+            return (short[]) value;
+
+        Short[] src = (Short[]) value;
+        short[] dst = new short[src.length];
+        for (int i = 0; i < src.length; i++)
+            dst[i] = src[i];
+        return dst;
+    }
+
+    static int[] toIntArray(Object value) {
+        if (value instanceof int[])
+            return (int[]) value;
+
+        Integer[] src = (Integer[]) value;
+        int[] dst = new int[src.length];
+        for (int i = 0; i < src.length; i++)
+            dst[i] = src[i];
+        return dst;
+    }
+
+    static long[] toLongArray(Object value) {
+        if (value instanceof long[])
+            return (long[]) value;
+
+        Long[] src = (Long[]) value;
+        long[] dst = new long[src.length];
+        for (int i = 0; i < src.length; i++)
+            dst[i] = src[i];
+        return dst;
+    }
+
+    static float[] toFloatArray(Object value) {
+        if (value instanceof float[])
+            return (float[]) value;
+
+        Float[] src = (Float[]) value;
+        float[] dst = new float[src.length];
+        for (int i = 0; i < src.length; i++)
+            dst[i] = src[i];
+        return dst;
+    }
+
+    static double[] toDoubleArray(Object value) {
+        if (value instanceof double[])
+            return (double[]) value;
+
+        Double[] src = (Double[]) value;
+        double[] dst = new double[src.length];
+        for (int i = 0; i < src.length; i++)
+            dst[i] = src[i];
+        return dst;
+    }
+}

--- a/protocol/src/main/java/com/nhnent/haste/protocol/data/DataObjectUtil.java
+++ b/protocol/src/main/java/com/nhnent/haste/protocol/data/DataObjectUtil.java
@@ -21,7 +21,7 @@ import java.nio.charset.Charset;
 import java.security.InvalidParameterException;
 
 class DataObjectUtil {
-    static final Charset UTF8 = Charset.forName("UTF-8");
+    private static final Charset UTF8 = Charset.forName("UTF-8");
 
     static DataType getType(Object object) {
         if (object instanceof Byte) {
@@ -40,19 +40,19 @@ class DataObjectUtil {
             return DataType.DOUBLE;
         } else if (object instanceof String) {
             return DataType.STRING;
-        } else if (object instanceof Byte[]) {
+        } else if (object instanceof Byte[] || object instanceof byte[]) {
             return DataType.BYTE_ARRAY;
-        } else if (object instanceof Boolean[]) {
+        } else if (object instanceof Boolean[] || object instanceof boolean[]) {
             return DataType.BOOL_ARRAY;
-        } else if (object instanceof Short[]) {
+        } else if (object instanceof Short[] || object instanceof short[]) {
             return DataType.INT16_ARRAY;
-        } else if (object instanceof Integer[]) {
+        } else if (object instanceof Integer[] || object instanceof int[]) {
             return DataType.INT32_ARRAY;
-        } else if (object instanceof Long[]) {
+        } else if (object instanceof Long[] || object instanceof long[]) {
             return DataType.INT64_ARRAY;
-        } else if (object instanceof Float[]) {
+        } else if (object instanceof Float[] || object instanceof float[]) {
             return DataType.FLOAT_ARRAY;
-        } else if (object instanceof Double[]) {
+        } else if (object instanceof Double[] || object instanceof double[]) {
             return DataType.DOUBLE_ARRAY;
         } else if (object instanceof String[]) {
             return DataType.STRING_ARRAY;
@@ -208,49 +208,49 @@ class DataObjectUtil {
         byteWrapper.writeInt(length);
         switch (dataType) {
             case BYTE_ARRAY: {
-                byte[] values = (byte[]) value;
+                byte[] values = ArrayUtils.toByteArray(value);
                 for (int i = 0; i < length; i++) {
                     byteWrapper.writeByte(values[i]);
                 }
                 break;
             }
             case BOOL_ARRAY: {
-                boolean[] values = (boolean[]) value;
+                boolean[] values = ArrayUtils.toBooleanArray(value);
                 for (int i = 0; i < length; i++) {
                     byteWrapper.writeBoolean(values[i]);
                 }
                 break;
             }
             case INT16_ARRAY: {
-                short[] values = (short[]) value;
+                short[] values = ArrayUtils.toShortArray(value);
                 for (int i = 0; i < length; i++) {
                     byteWrapper.writeShort(values[i]);
                 }
                 break;
             }
             case INT32_ARRAY: {
-                int[] values = (int[]) value;
+                int[] values = ArrayUtils.toIntArray(value);
                 for (int i = 0; i < length; i++) {
                     byteWrapper.writeInt(values[i]);
                 }
                 break;
             }
             case INT64_ARRAY: {
-                long[] values = (long[]) value;
+                long[] values = ArrayUtils.toLongArray(value);
                 for (int i = 0; i < length; i++) {
                     byteWrapper.writeLong(values[i]);
                 }
                 break;
             }
             case FLOAT_ARRAY: {
-                float[] values = (float[]) value;
+                float[] values = ArrayUtils.toFloatArray(value);
                 for (int i = 0; i < length; i++) {
                     byteWrapper.writeFloat(values[i]);
                 }
                 break;
             }
             case DOUBLE_ARRAY: {
-                double[] values = (double[]) value;
+                double[] values = ArrayUtils.toDoubleArray(value);
                 for (int i = 0; i < length; i++) {
                     byteWrapper.writeDouble(values[i]);
                 }

--- a/protocol/src/test/java/com/nhnent/haste/protocol/data/DataObjectUtilTest.java
+++ b/protocol/src/test/java/com/nhnent/haste/protocol/data/DataObjectUtilTest.java
@@ -1,0 +1,248 @@
+/*
+* Copyright 2016 NHN Entertainment Corp.
+*
+* NHN Entertainment Corp. licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.nhnent.haste.protocol.data;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class DataObjectUtilTest {
+    private static final byte BYTE_DATA = 12;
+    private static final boolean BOOLEAN_DATA = true;
+    private static final short SHORT_DATA = 34;
+    private static final int INT_DATA = 56;
+    private static final long LONG_DATA = 78;
+    private static final float FLOAT_DATA = 9.10f;
+    private static final double DOUBLE_DATA = 11.12;
+    private static final String STRING_DATA = "test";
+
+    private static final byte[] BYTE_ARRAY_DATA = {1, 2};
+    private static final boolean[] BOOLEAN_ARRAY_DATA = {true, false};
+    private static final short[] SHORT_ARRAY_DATA = {3, 4};
+    private static final int[] INT_ARRAY_DATA = {5, 6};
+    private static final long[] LONG_ARRAY_DATA = {7L, 8L};
+    private static final float[] FLOAT_ARRAY_DATA = {9.10f, 10.11f};
+    private static final double[] DOUBLE_ARRAY_DATA = {11.12, 12.13};
+
+    private static final Byte[] BYTE_OBJECT_ARRAY_DATA = {1, 2};
+    private static final Boolean[] BOOLEAN_OBJECT_ARRAY_DATA = {true};
+    private static final Short[] SHORT_OBJECT_ARRAY_DATA = {3, 4};
+    private static final Integer[] INT_OBJECT_ARRAY_DATA = {5, 6};
+    private static final Long[] LONG_OBJECT_ARRAY_DATA = {7L, 8L};
+    private static final Float[] FLOAT_OBJECT_ARRAY_DATA = {9.10f, 10.11f};
+    private static final Double[] DOUBLE_OBJECT_ARRAY_DATA = {11.12, 12.13};
+    private static final String[] STRING_OBJECT_ARRAY_DATA = {"test", "test2"};
+
+    @Test
+    public void testGetType() throws Exception {
+        Assert.assertEquals(DataType.BYTE, DataObjectUtil.getType(BYTE_DATA));
+        Assert.assertEquals(DataType.BOOL, DataObjectUtil.getType(BOOLEAN_DATA));
+        Assert.assertEquals(DataType.INT16, DataObjectUtil.getType(SHORT_DATA));
+        Assert.assertEquals(DataType.INT32, DataObjectUtil.getType(INT_DATA));
+        Assert.assertEquals(DataType.INT64, DataObjectUtil.getType(LONG_DATA));
+        Assert.assertEquals(DataType.FLOAT, DataObjectUtil.getType(FLOAT_DATA));
+        Assert.assertEquals(DataType.DOUBLE, DataObjectUtil.getType(DOUBLE_DATA));
+        Assert.assertEquals(DataType.STRING, DataObjectUtil.getType(STRING_DATA));
+
+        Assert.assertEquals(DataType.BYTE_ARRAY, DataObjectUtil.getType(BYTE_OBJECT_ARRAY_DATA));
+        Assert.assertEquals(DataType.BOOL_ARRAY, DataObjectUtil.getType(BOOLEAN_OBJECT_ARRAY_DATA));
+        Assert.assertEquals(DataType.INT16_ARRAY, DataObjectUtil.getType(SHORT_OBJECT_ARRAY_DATA));
+        Assert.assertEquals(DataType.INT32_ARRAY, DataObjectUtil.getType(INT_OBJECT_ARRAY_DATA));
+        Assert.assertEquals(DataType.INT64_ARRAY, DataObjectUtil.getType(LONG_OBJECT_ARRAY_DATA));
+        Assert.assertEquals(DataType.FLOAT_ARRAY, DataObjectUtil.getType(FLOAT_OBJECT_ARRAY_DATA));
+        Assert.assertEquals(DataType.DOUBLE_ARRAY, DataObjectUtil.getType(DOUBLE_OBJECT_ARRAY_DATA));
+        Assert.assertEquals(DataType.STRING_ARRAY, DataObjectUtil.getType(STRING_OBJECT_ARRAY_DATA));
+
+        Assert.assertEquals(DataType.BYTE_ARRAY, DataObjectUtil.getType(BYTE_ARRAY_DATA));
+        Assert.assertEquals(DataType.BOOL_ARRAY, DataObjectUtil.getType(BOOLEAN_ARRAY_DATA));
+        Assert.assertEquals(DataType.INT16_ARRAY, DataObjectUtil.getType(SHORT_ARRAY_DATA));
+        Assert.assertEquals(DataType.INT32_ARRAY, DataObjectUtil.getType(INT_ARRAY_DATA));
+        Assert.assertEquals(DataType.INT64_ARRAY, DataObjectUtil.getType(LONG_ARRAY_DATA));
+        Assert.assertEquals(DataType.FLOAT_ARRAY, DataObjectUtil.getType(FLOAT_ARRAY_DATA));
+        Assert.assertEquals(DataType.DOUBLE_ARRAY, DataObjectUtil.getType(DOUBLE_ARRAY_DATA));
+    }
+
+    @Test
+    public void testWriteAndReadPrimitiveType() {
+        ByteWrapper byteWrapper = new ByteWrapper(1024);
+        DataObjectUtil.writeData(new DataWrapper(DataType.BYTE, BYTE_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.BOOL, BOOLEAN_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.INT16, SHORT_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.INT32, INT_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.INT64, LONG_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.FLOAT, FLOAT_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.DOUBLE, DOUBLE_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.STRING, STRING_DATA), byteWrapper);
+
+        DataWrapper byteDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper booleanDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper shortDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper intDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper longDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper floatDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper doubleDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper stringDataWrapper = DataObjectUtil.readData(byteWrapper);
+
+        Assert.assertEquals(DataType.BYTE, byteDataWrapper.type);
+        Assert.assertEquals(DataType.BOOL, booleanDataWrapper.type);
+        Assert.assertEquals(DataType.INT16, shortDataWrapper.type);
+        Assert.assertEquals(DataType.INT32, intDataWrapper.type);
+        Assert.assertEquals(DataType.INT64, longDataWrapper.type);
+        Assert.assertEquals(DataType.FLOAT, floatDataWrapper.type);
+        Assert.assertEquals(DataType.DOUBLE, doubleDataWrapper.type);
+        Assert.assertEquals(DataType.STRING, stringDataWrapper.type);
+
+        Assert.assertEquals(BYTE_DATA, byteDataWrapper.value);
+        Assert.assertEquals(BOOLEAN_DATA, booleanDataWrapper.value);
+        Assert.assertEquals(SHORT_DATA, shortDataWrapper.value);
+        Assert.assertEquals(INT_DATA, intDataWrapper.value);
+        Assert.assertEquals(LONG_DATA, longDataWrapper.value);
+        Assert.assertEquals(FLOAT_DATA, floatDataWrapper.value);
+        Assert.assertEquals(DOUBLE_DATA, doubleDataWrapper.value);
+        Assert.assertEquals(STRING_DATA, stringDataWrapper.value);
+    }
+
+    @Test
+    public void testWriteAndReadPrimitiveArrayType() {
+        ByteWrapper byteWrapper = new ByteWrapper(1024);
+        DataObjectUtil.writeData(new DataWrapper(DataType.BYTE_ARRAY, BYTE_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.BOOL_ARRAY, BOOLEAN_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.INT16_ARRAY, SHORT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.INT32_ARRAY, INT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.INT64_ARRAY, LONG_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.FLOAT_ARRAY, FLOAT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.DOUBLE_ARRAY, DOUBLE_ARRAY_DATA), byteWrapper);
+
+        DataWrapper byteDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper booleanDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper shortDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper intDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper longDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper floatDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper doubleDataWrapper = DataObjectUtil.readData(byteWrapper);
+
+        // Cast to primitive array type because Assert::assertArrayEquals can't pass Object parameter
+        byte[] byteArrayData = (byte[]) byteDataWrapper.value;
+        boolean[] booleanArrayData = (boolean[]) booleanDataWrapper.value;
+        short[] shortArrayData = (short[]) shortDataWrapper.value;
+        int[] intArrayData = (int[]) intDataWrapper.value;
+        long[] longArrayData = (long[]) longDataWrapper.value;
+        float[] floatArrayData = (float[]) floatDataWrapper.value;
+        double[] doubleArrayData = (double[]) doubleDataWrapper.value;
+
+        Assert.assertArrayEquals(BYTE_ARRAY_DATA, byteArrayData);
+        Assert.assertArrayEquals(BOOLEAN_ARRAY_DATA, booleanArrayData);
+        Assert.assertArrayEquals(SHORT_ARRAY_DATA, shortArrayData);
+        Assert.assertArrayEquals(INT_ARRAY_DATA, intArrayData);
+        Assert.assertArrayEquals(LONG_ARRAY_DATA, longArrayData);
+        Assert.assertArrayEquals(FLOAT_ARRAY_DATA, floatArrayData, 0.0001f);
+        Assert.assertArrayEquals(DOUBLE_ARRAY_DATA, doubleArrayData, 0.0001);
+    }
+
+    @Test
+    public void testWriteAndReadObjectArrayType() {
+        ByteWrapper byteWrapper = new ByteWrapper(1024);
+        DataObjectUtil.writeData(new DataWrapper(DataType.BYTE_ARRAY, BYTE_OBJECT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.BOOL_ARRAY, BOOLEAN_OBJECT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.INT16_ARRAY, SHORT_OBJECT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.INT32_ARRAY, INT_OBJECT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.INT64_ARRAY, LONG_OBJECT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.FLOAT_ARRAY, FLOAT_OBJECT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.DOUBLE_ARRAY, DOUBLE_OBJECT_ARRAY_DATA), byteWrapper);
+        DataObjectUtil.writeData(new DataWrapper(DataType.STRING_ARRAY, STRING_OBJECT_ARRAY_DATA), byteWrapper);
+
+        DataWrapper byteDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper booleanDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper shortDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper intDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper longDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper floatDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper doubleDataWrapper = DataObjectUtil.readData(byteWrapper);
+        DataWrapper stringDataWrapper = DataObjectUtil.readData(byteWrapper);
+
+        // DataObjectUtil::readData returns primitive array type although written data was object array type
+        byte[] byteArrayData = (byte[]) byteDataWrapper.value;
+        boolean[] booleanArrayData = (boolean[]) booleanDataWrapper.value;
+        short[] shortArrayData = (short[]) shortDataWrapper.value;
+        int[] intArrayData = (int[]) intDataWrapper.value;
+        long[] longArrayData = (long[]) longDataWrapper.value;
+        float[] floatArrayData = (float[]) floatDataWrapper.value;
+        double[] doubleArrayData = (double[]) doubleDataWrapper.value;
+        String[] stringArrayData = (String[]) stringDataWrapper.value;
+
+        Assert.assertArrayEquals(BYTE_OBJECT_ARRAY_DATA, Util.toObjectArray(byteArrayData));
+        Assert.assertArrayEquals(BOOLEAN_OBJECT_ARRAY_DATA, Util.toObjectArray(booleanArrayData));
+        Assert.assertArrayEquals(SHORT_OBJECT_ARRAY_DATA, Util.toObjectArray(shortArrayData));
+        Assert.assertArrayEquals(INT_OBJECT_ARRAY_DATA, Util.toObjectArray(intArrayData));
+        Assert.assertArrayEquals(LONG_OBJECT_ARRAY_DATA, Util.toObjectArray(longArrayData));
+        Assert.assertArrayEquals(FLOAT_OBJECT_ARRAY_DATA, Util.toObjectArray(floatArrayData));
+        Assert.assertArrayEquals(DOUBLE_OBJECT_ARRAY_DATA, Util.toObjectArray(doubleArrayData));
+        Assert.assertArrayEquals(STRING_OBJECT_ARRAY_DATA, stringArrayData);
+    }
+
+    static class Util {
+        static Byte[] toObjectArray(byte[] src) {
+            Byte[] dst = new Byte[src.length];
+            for (int i = 0; i < src.length; i++)
+                dst[i] = src[i];
+            return dst;
+        }
+
+        static Boolean[] toObjectArray(boolean[] src) {
+            Boolean[] dst = new Boolean[src.length];
+            for (int i = 0; i < src.length; i++)
+                dst[i] = src[i];
+            return dst;
+        }
+
+        static Short[] toObjectArray(short[] src) {
+            Short[] dst = new Short[src.length];
+            for (int i = 0; i < src.length; i++)
+                dst[i] = src[i];
+            return dst;
+        }
+
+        static Integer[] toObjectArray(int[] src) {
+            Integer[] dst = new Integer[src.length];
+            for (int i = 0; i < src.length; i++)
+                dst[i] = src[i];
+            return dst;
+        }
+
+        static Long[] toObjectArray(long[] src) {
+            Long[] dst = new Long[src.length];
+            for (int i = 0; i < src.length; i++)
+                dst[i] = src[i];
+            return dst;
+        }
+
+        static Float[] toObjectArray(float[] src) {
+            Float[] dst = new Float[src.length];
+            for (int i = 0; i < src.length; i++)
+                dst[i] = src[i];
+            return dst;
+        }
+
+        static Double[] toObjectArray(double[] src) {
+            Double[] dst = new Double[src.length];
+            for (int i = 0; i < src.length; i++)
+                dst[i] = src[i];
+            return dst;
+        }
+    }
+}


### PR DESCRIPTION
# Motivation
- It can't understand primitive array type in data object, and can't write object wrapping type array.

# Modification
- Add if statements that can understand primitive array type. And add a util class for manipulating array.

# Result
- It can understand primitive array type, and write object wrapping type array.