### PR TITLE
Filter logs using log level

### DIFF
--- a/framework/src/main/java/com/nhnent/haste/framework/ClientPeer.java
+++ b/framework/src/main/java/com/nhnent/haste/framework/ClientPeer.java
@@ -129,7 +129,8 @@ public abstract class ClientPeer implements ApplicationPeer {
         if (isEncrypted) {
             byte[] decryptedPayload = this.cryptoProvider.decrypt(payloadBytes, 0, payloadLength);
             if (decryptedPayload == null) {
-                logger.warn("Failed Encrypted Data : length[{}]", payloadLength);
+                if (logger.isWarnEnabled())
+                    logger.warn("Failed Encrypted Data : length[{}]", payloadLength);
                 return;
             }
             payloadBytes = decryptedPayload;

--- a/transport-udp/src/main/java/com/nhnent/haste/transport/udp/Channel.java
+++ b/transport-udp/src/main/java/com/nhnent/haste/transport/udp/Channel.java
@@ -182,8 +182,9 @@ public final class Channel {
             long rto = command.getRetransmissionTimeout();
 
             if (command.getSentCount() > OutgoingCommand.MAX_RESEND_COUNT) {
-                logger.debug("Failed to resend, relSeq[{}] currentTime[{}] rto[{}] sentTime[{}] sentCount[{}]",
-                        command.getReliableSeqNum(), currentTime, rto, command.getSentTime(), command.getSentCount());
+                if (logger.isDebugEnabled())
+                    logger.debug("Failed to resend, relSeq[{}] currentTime[{}] rto[{}] sentTime[{}] sentCount[{}]",
+                            command.getReliableSeqNum(), currentTime, rto, command.getSentTime(), command.getSentCount());
                 return false;
             }
 


### PR DESCRIPTION
# Motivation
- Although can't print logs because of log level, it is using unnecessary ticks

# Modification
- Depending on log level, it can skip log statement.

# Result
- Don't use unnecessary ticks